### PR TITLE
Fix windows build and add tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,50 @@
+name: tzdata contents
+
+on: [push]
+
+jobs:
+  tests:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+    env:
+      TOXENV: py
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: ${{ matrix.python-version }} - ${{ matrix.os }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox
+    - name: Run tests
+      run: |
+        tox
+
+  other:
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        toxenv: ["build", "pytype"]
+    env:
+      TOXENV: ${{ matrix.toxenv }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: ${{ matrix.toxenv }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
+      - name: Run action
+        run: |
+          tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     env:
       TOXENV: py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include src/tzdata/ *
+recursive-include src/tzdata *

--- a/tests/test_contents.py
+++ b/tests/test_contents.py
@@ -1,9 +1,29 @@
+import sys
+
+import pytest
+
 try:
     from importlib import resources
 except ImportError:
     import importlib_resources as resources
 
-import pytest
+
+if sys.version_info < (3, 6):
+    # pytest-subtests does not support Python < 3.6, but having the tests
+    # separated into clean subtests is nice but not required, so we will create
+    # a stub that does nothing but at least doesn't fail for lack of a fixture.
+    import contextlib
+
+    class _SubTestStub:
+        @contextlib.contextmanager
+        def test(self, **kwargs):
+            yield
+
+    _sub_test_stub = _SubTestStub()
+
+    @pytest.fixture
+    def subtests():
+        yield _sub_test_stub
 
 
 def get_magic(zone_name):

--- a/tests/test_contents.py
+++ b/tests/test_contents.py
@@ -1,0 +1,67 @@
+try:
+    from importlib import resources
+except ImportError:
+    import importlib_resources as resources
+
+import pytest
+
+
+def get_magic(zone_name):
+    components = zone_name.split("/")
+    package_name = ".".join(["tzdata.zoneinfo"] + components[:-1])
+    resource_name = components[-1]
+
+    with resources.open_binary(package_name, resource_name) as f:
+        return f.read(4)
+
+
+@pytest.mark.parametrize(
+    "zone_name",
+    [
+        "Africa/Cairo",
+        "Africa/Casablanca",
+        "Africa/Lome",
+        "America/Argentina/San_Luis",
+        "America/Denver",
+        "America/Los_Angeles",
+        "America/New_York",
+        "America/Thunder_Bay",
+        "Antarctica/South_Pole",
+        "Asia/Calcutta",
+        "Asia/Damascus",
+        "Asia/Seoul",
+        "Atlantic/Reykjavik",
+        "Australia/Perth",
+        "Egypt",
+        "Etc/GMT-9",
+        "Europe/Dublin",
+        "Europe/London",
+        "Europe/Prague",
+        "Hongkong",
+        "Indian/Cocos",
+        "Indian/Mayotte",
+        "Mexico/BajaNorte",
+        "Pacific/Guam",
+        "Pacific/Kiritimati",
+        "US/Eastern",
+        "UTC",
+    ],
+)
+def test_zone_valid(zone_name):
+    """Test an assortment of hard-coded zone names.
+
+    This test checks that the zone resource can be loaded and that it starts
+    with the 4-byte magic indicating a TZif file.
+    """
+    magic = get_magic(zone_name)
+    assert magic == b"TZif"
+
+
+def test_load_zones(subtests):
+    with resources.open_text("tzdata", "zones") as f:
+        zones = [z.strip() for z in f]
+
+    for zone in zones:
+        with subtests.test(zone=zone):
+            magic = get_magic(zone)
+            assert magic == b"TZif"

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skip_missing_interpreters = true
 description = Test that the tzdata contents are accessible
 deps =
     pytest
-    pytest-subtests
+    pytest-subtests; python_version>='3.6'
     importlib_resources; python_version<'3.7'
 commands =
     pytest {toxinidir} {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,15 @@ minversion = 3.3.0
 isolated_build = True
 skip_missing_interpreters = true
 
+[testenv]
+description = Test that the tzdata contents are accessible
+deps =
+    pytest
+    pytest-subtests
+    importlib_resources; python_version<'3.7'
+commands =
+    pytest {toxinidir} {posargs}
+
 [testenv:update]
 description = Update the tzdata contents
 skip_install = True
@@ -30,7 +39,7 @@ deps =
 commands =
     black .
     isort update.py
-
+    isort --atomic -rc tests
 
 [testenv:build]
 description = Build a wheel and source distribution


### PR DESCRIPTION
Apparently the Windows build never worked, because there was a trailing / in the `MANIFEST.in`. This fixes that and also adds GHA and tests to prevent this from happening again.

I have two testing strategies here:

1. Test that every file in the `zones` list (and the `zones` list itself) is included in the package and contains a TZif file.
2. Test a smattering of hard-coded zones - this is in case the zones list populates incorrectly for some reason (e.g. an empty list). I didn't want to exhaustively list all the zones because that seems too much to maintain, but I figure *some* hard-coded zones from each of the general areas should be a good canary in the coal mine.

Fixes #9.