### PR TITLE
Use a PEP 440-compliant versioning scheme

### DIFF
--- a/src/tzdata/__init__.py
+++ b/src/tzdata/__init__.py
@@ -1,3 +1,7 @@
+# IANA versions like 2020a are not valid PEP 440 identifiers; the recommended
+# way to translate the version is to use YYYY.n where `n` is a 1-based index.
+__version__ = "2020.1"
+
+# This exposes the original IANA version number.
 IANA_VERSION = "2020a"
 
-__version__ = IANA_VERSION

--- a/templates/__init__.py.in
+++ b/templates/__init__.py.in
@@ -1,3 +1,7 @@
+# IANA versions like 2020a are not valid PEP 440 identifiers; the recommended
+# way to translate the version is to use YYYY.n where `n` is a 0-based index.
+__version__ = %%PACKAGE_VERSION%%
+
+# This exposes the original IANA version number.
 IANA_VERSION = %%IANA_VERSION%%
 
-__version__ = IANA_VERSION


### PR DESCRIPTION
The type of translation to do here is explicitly mentioned in PEP 440, and this will help prevent anything from interpreting "2020a" as an alpha release.